### PR TITLE
Prevent search reset...

### DIFF
--- a/src/fhirBrowser.js
+++ b/src/fhirBrowser.js
@@ -29,6 +29,7 @@ if ('serviceWorker' in navigator) {
             const bundle = this._shadow.getElementById("bundle");
             bundle.hidden = true;
             const resource = this._shadow.getElementById("resource");
+            resource.hidden = false;
             resource.load({
                 "resourceType": resourceType,
                 "resourceId": id
@@ -47,7 +48,7 @@ if ('serviceWorker' in navigator) {
             bundle.load(resourceType, search);
         }
 
-        locationHandler = async () => {
+        locationHandler = async ({oldURL}) => {
             let hash = window.location.hash.replace('#', '').trim();
             if (hash.length) {
                 let id = '';
@@ -75,7 +76,14 @@ if ('serviceWorker' in navigator) {
                 if (id) {
                     this.showResource(resourceType, id);
                 } else {
-                    this.showBundle(resourceType, queryParams);
+                    if (oldURL.includes(resourceType.type)) {
+                        const bundle = this._shadow.getElementById("bundle");
+                        bundle.hidden = false;
+                        const resource = this._shadow.getElementById("resource");
+                        resource.hidden = true
+                    } else {
+                        this.showBundle(resourceType, queryParams);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When searching among a resource type, and displaying a given resource, the back arrow reload the whole resource bundle, overwriting the search result. This is annoying, and this comits prevents from reloading the whole bundle and keeps the search result